### PR TITLE
Add 'smove' method to Kredis::Types::Set

### DIFF
--- a/lib/kredis/types/set.rb
+++ b/lib/kredis/types/set.rb
@@ -3,7 +3,7 @@
 class Kredis::Types::Set < Kredis::Types::Proxying
   prepend Kredis::DefaultValues
 
-  proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop, :exists?, :srandmember
+  proxying :smembers, :sadd, :srem, :multi, :del, :sismember, :scard, :spop, :exists?, :srandmember, :smove
 
   attr_accessor :typed
 


### PR DESCRIPTION
the Redis documentation currently supports the use of the `smove` method, this change make that method also available in kredis

 example:
     my_kredis_set.smove(another_kredis_set.key, value_to_move)

use case:
   when using sets as queues for a multi step process it is helpful to move values between sets: 
        queued -> issued
        issued -> completed
        issued -> failed & add back to queued for retying

https://redis.io/docs/latest/commands/smove/